### PR TITLE
The Require all granted option is required by our setup

### DIFF
--- a/web/templates/web/vhost.conf
+++ b/web/templates/web/vhost.conf
@@ -10,9 +10,10 @@
 		AllowOverride All
 		Order allow,deny
 		Allow from all
+		Require all granted
 	</Directory>
 	# php-fpm
-	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/tmp/php.sock|fcgi://localhost/{{ vhost.webroot }}/htdocs
+	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/tmp/php.sock|fcgi://localhost{{ vhost.webroot }}/htdocs
 	# logging
 	ErrorLog "{{ vhost.webroot }}/logs/error.log"
 	CustomLog "{{ vhost.webroot }}/logs/access.log" common
@@ -31,6 +32,7 @@
 		AllowOverride All
 		Order allow,deny
 		Allow from all
+		Require all granted
 	</Directory>
 	# ssl
 	SSLEngine On
@@ -38,7 +40,7 @@
 	SSLCertificateKeyFile {{ vhost.cert.bundle_name }}
 	SSLCACertificateFile  {{ vhost.cert.bundle_name }}
 	# php-fpm
-	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/tmp/php.sock|fcgi://localhost/{{ vhost.webroot }}/htdocs
+	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/tmp/php.sock|fcgi://localhost{{ vhost.webroot }}/htdocs
 	# logging
 	ErrorLog "{{ vhost.webroot }}/logs/error.log"
 	CustomLog "{{ vhost.webroot }}/logs/access.log" common


### PR DESCRIPTION
The `Require all granted` option is required on our (default) apache setup on SmartOS
