### PR TITLE
Use alternative to ProxyPassMatch command because of regex issues

### DIFF
--- a/web/templates/web/vhost.conf
+++ b/web/templates/web/vhost.conf
@@ -13,7 +13,9 @@
 		Require all granted
 	</Directory>
 	# php-fpm
-	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/tmp/php.sock|fcgi://localhost{{ vhost.webroot }}/htdocs
+	<FilesMatch \.php$>
+		SetHandler "proxy:unix:/tmp/php.sock|fcgi://localhost"
+	</FilesMatch>
 	# logging
 	ErrorLog "{{ vhost.webroot }}/logs/error.log"
 	CustomLog "{{ vhost.webroot }}/logs/access.log" common
@@ -40,7 +42,9 @@
 	SSLCertificateKeyFile {{ vhost.cert.bundle_name }}
 	SSLCACertificateFile  {{ vhost.cert.bundle_name }}
 	# php-fpm
-	ProxyPassMatch ^/(.*\.php(/.*)?)$ unix:/tmp/php.sock|fcgi://localhost{{ vhost.webroot }}/htdocs
+	<FilesMatch \.php$>
+		SetHandler "proxy:unix:/tmp/php.sock|fcgi://localhost"
+	</FilesMatch>
 	# logging
 	ErrorLog "{{ vhost.webroot }}/logs/error.log"
 	CustomLog "{{ vhost.webroot }}/logs/access.log" common


### PR DESCRIPTION
The biggest problem with the ProxyPassMatch is the strange regex format which sometimes didn't match the php files. It's much easier to use the FileMatch option with SetHandler. Works and tested with the newest apache 2.4 version.