### PR TITLE
Feature/idn support

### DIFF
--- a/kumquat/models.py
+++ b/kumquat/models.py
@@ -6,6 +6,9 @@ class Domain(models.Model):
 	name = models.CharField(max_length=255, unique=True, verbose_name=_('Name'), help_text=_('Your primary domain (example.com) that you like to use for the different services.'), validators=[DomainNameValidator()])
 
 	def __unicode__(self):
+		return self.name.decode("idna")
+
+	def punnycode(self):
 		return self.name
 
 	def save(self, **kwargs):

--- a/kumquat/models.py
+++ b/kumquat/models.py
@@ -8,7 +8,7 @@ class Domain(models.Model):
 	def __unicode__(self):
 		return self.name.decode("idna")
 
-	def punnycode(self):
+	def punycode(self):
 		return self.name
 
 	def save(self, **kwargs):

--- a/kumquat/models.py
+++ b/kumquat/models.py
@@ -7,3 +7,7 @@ class Domain(models.Model):
 
 	def __unicode__(self):
 		return self.name
+
+	def save(self, **kwargs):
+		self.name = self.name.encode("idna")
+		super(Domain, self).save(**kwargs)

--- a/kumquat/templates/kumquat/domain_list.html
+++ b/kumquat/templates/kumquat/domain_list.html
@@ -17,7 +17,7 @@
 		</thead>
 		{% for domain in object_list %}
 		<tr>
-			<td>{{ domain.name }}</td>
+			<td>{{ domain }}</td>
 			<td>
 				<form action="{% url "domain_delete" domain.id %}" method="post" class="confirm-delete">
 					{% csrf_token %}

--- a/mail/views.py
+++ b/mail/views.py
@@ -77,23 +77,23 @@ def export(request):
 	
 	data = {}
 	for domain in Domain.objects.all():
-		punnycode_domain = unicode(domain.punnycode())
-		data[punnycode_domain] = {
+		punycode_domain = unicode(domain.punycode())
+		data[punycode_domain] = {
 			"account": [],
 			"alias":   [],
 		}
 		for account in domain.mail_accounts.all():
 			spoofing_whitelist = getattr(settings, 'CORE_MAIL_WHITELIST', None)
 			if spoofing_whitelist == None:
-				spoofing_whitelist = punnycode_domain
-			data[punnycode_domain]["account"] += [{
+				spoofing_whitelist = punycode_domain
+			data[punycode_domain]["account"] += [{
 				"name":                 account.name,
 				"password":             account.password,
 				"spoofing_whitelist":   spoofing_whitelist,
 				"subaddress_extension": account.subaddress,
 			}]
 		for redirect in domain.redirect_set.all():
-			data[punnycode_domain]["alias"] += [{
+			data[punycode_domain]["alias"] += [{
 				"name": redirect.name,
 				"to":   redirect.to,
 			}]

--- a/mail/views.py
+++ b/mail/views.py
@@ -77,22 +77,23 @@ def export(request):
 	
 	data = {}
 	for domain in Domain.objects.all():
-		data[unicode(domain)] = {
+		punnycode_domain = unicode(domain.punnycode())
+		data[punnycode_domain] = {
 			"account": [],
 			"alias":   [],
 		}
 		for account in domain.mail_accounts.all():
 			spoofing_whitelist = getattr(settings, 'CORE_MAIL_WHITELIST', None)
 			if spoofing_whitelist == None:
-				spoofing_whitelist = unicode(domain)
-			data[unicode(domain)]["account"] += [{
+				spoofing_whitelist = punnycode_domain
+			data[punnycode_domain]["account"] += [{
 				"name":                 account.name,
 				"password":             account.password,
 				"spoofing_whitelist":   spoofing_whitelist,
 				"subaddress_extension": account.subaddress,
 			}]
 		for redirect in domain.redirect_set.all():
-			data[unicode(domain)]["alias"] += [{
+			data[punnycode_domain]["alias"] += [{
 				"name": redirect.name,
 				"to":   redirect.to,
 			}]

--- a/web/management/commands/update_vhosts.py
+++ b/web/management/commands/update_vhosts.py
@@ -18,7 +18,7 @@ def write_vhost_config():
 			'vhost': vhost,
 		}
 		try:
-			config += render_to_string('web/vhost-' + str(vhost.punnycode()) + '.conf', context)
+			config += render_to_string('web/vhost-' + str(vhost.punycode()) + '.conf', context)
 		except:
 			config += render_to_string('web/vhost.conf', context)
 
@@ -33,7 +33,7 @@ def webroot_dataset(vhost):
 
 def update_filesystem():
 	dirs   = set(os.listdir(settings.KUMQUAT_VHOST_ROOT)) - set(['.Trash'])
-	vhosts = set([str(vhost.punnycode()) for vhost in VHost.objects.all()])
+	vhosts = set([str(vhost.punycode()) for vhost in VHost.objects.all()])
 
 	remove = dirs - vhosts
 	create = vhosts - dirs

--- a/web/management/commands/update_vhosts.py
+++ b/web/management/commands/update_vhosts.py
@@ -22,8 +22,6 @@ def write_vhost_config():
 		except:
 			config += render_to_string('web/vhost.conf', context)
 
-	print(config)
-
 	with open(settings.KUMQUAT_VHOST_CONFIG, 'w') as f:
 		f.write(config)
 

--- a/web/management/commands/update_vhosts.py
+++ b/web/management/commands/update_vhosts.py
@@ -18,9 +18,11 @@ def write_vhost_config():
 			'vhost': vhost,
 		}
 		try:
-			config += render_to_string('web/vhost-' + str(vhost) + '.conf', context)
+			config += render_to_string('web/vhost-' + str(vhost.punnycode()) + '.conf', context)
 		except:
 			config += render_to_string('web/vhost.conf', context)
+
+	print(config)
 
 	with open(settings.KUMQUAT_VHOST_CONFIG, 'w') as f:
 		f.write(config)
@@ -33,11 +35,11 @@ def webroot_dataset(vhost):
 
 def update_filesystem():
 	dirs   = set(os.listdir(settings.KUMQUAT_VHOST_ROOT)) - set(['.Trash'])
-	vhosts = set([str(vhost) for vhost in VHost.objects.all()])
+	vhosts = set([str(vhost.punnycode()) for vhost in VHost.objects.all()])
 
 	remove = dirs - vhosts
 	create = vhosts - dirs
-	
+
 	for vhost in create:
 		if settings.KUMQUAT_USE_ZFS:
 			call(['zfs', 'create', webroot_dataset(vhost)])

--- a/web/models.py
+++ b/web/models.py
@@ -15,10 +15,13 @@ class VHost(models.Model):
 	cert   = models.ForeignKey('SSLCert', blank=True, null=True, on_delete=models.SET_NULL, verbose_name='SSL Certificate')
 
 	def webroot(self):
-		return settings.KUMQUAT_VHOST_ROOT + '/' + str(self)
+		return settings.KUMQUAT_VHOST_ROOT + '/' + str(self.punnycode())
 
 	def __unicode__(self):
 		return unicode(self.name) + '.' + unicode(self.domain)
+
+	def punnycode(self):
+		return unicode(self.name) + '.' + unicode(self.domain.punnycode())
 
 	class Meta:
 		unique_together = (("name", "domain"),)

--- a/web/models.py
+++ b/web/models.py
@@ -15,13 +15,13 @@ class VHost(models.Model):
 	cert   = models.ForeignKey('SSLCert', blank=True, null=True, on_delete=models.SET_NULL, verbose_name='SSL Certificate')
 
 	def webroot(self):
-		return settings.KUMQUAT_VHOST_ROOT + '/' + str(self.punnycode())
+		return settings.KUMQUAT_VHOST_ROOT + '/' + str(self.punycode())
 
 	def __unicode__(self):
 		return unicode(self.name) + '.' + unicode(self.domain)
 
-	def punnycode(self):
-		return unicode(self.name) + '.' + unicode(self.domain.punnycode())
+	def punycode(self):
+		return unicode(self.name) + '.' + unicode(self.domain.punycode())
 
 	class Meta:
 		unique_together = (("name", "domain"),)

--- a/web/templates/web/vhost.conf
+++ b/web/templates/web/vhost.conf
@@ -1,9 +1,9 @@
 <VirtualHost *:80>
-	ServerName {{ vhost.punnycode }}
+	ServerName {{ vhost.punycode }}
 	{% if vhost.defaultvhost_set.count %}
-	ServerAlias *.{{ vhost.domain.punnycode }} {{ vhost.domain.punnycode }}
+	ServerAlias *.{{ vhost.domain.punycode }} {{ vhost.domain.punycode }}
 	{% endif %}
-	ServerAdmin admin@{{ vhost.domain.punnycode }}
+	ServerAdmin admin@{{ vhost.domain.punycode }}
 	# directory
 	DocumentRoot "{{ vhost.webroot }}/htdocs"
 	<Directory "{{ vhost.webroot }}/htdocs">
@@ -23,11 +23,11 @@
 
 {% if vhost.cert %}
 <VirtualHost *:443>
-	ServerName {{ vhost.punnycode }}
+	ServerName {{ vhost.punycode }}
 	{% if vhost.defaultvhost_set.count %}
-	ServerAlias *.{{ vhost.domain.punnycode }} {{ vhost.domain.punnycode }}
+	ServerAlias *.{{ vhost.domain.punycode }} {{ vhost.domain.punycode }}
 	{% endif %}
-	ServerAdmin admin@{{ vhost.domain.punnycode }}
+	ServerAdmin admin@{{ vhost.domain.punycode }}
 	# directory
 	DocumentRoot "{{ vhost.webroot }}/htdocs"
 	<Directory "{{ vhost.webroot }}/htdocs">

--- a/web/templates/web/vhost.conf
+++ b/web/templates/web/vhost.conf
@@ -1,9 +1,9 @@
 <VirtualHost *:80>
-	ServerName {{ vhost }}
+	ServerName {{ vhost.punnycode }}
 	{% if vhost.defaultvhost_set.count %}
-	ServerAlias *.{{ vhost.domain }} {{ vhost.domain }}
+	ServerAlias *.{{ vhost.domain.punnycode }} {{ vhost.domain.punnycode }}
 	{% endif %}
-	ServerAdmin admin@{{ vhost.domain }}
+	ServerAdmin admin@{{ vhost.domain.punnycode }}
 	# directory
 	DocumentRoot "{{ vhost.webroot }}/htdocs"
 	<Directory "{{ vhost.webroot }}/htdocs">
@@ -23,11 +23,11 @@
 
 {% if vhost.cert %}
 <VirtualHost *:443>
-	ServerName {{ vhost }}
+	ServerName {{ vhost.punnycode }}
 	{% if vhost.defaultvhost_set.count %}
-	ServerAlias *.{{ vhost.domain }} {{ vhost.domain }}
+	ServerAlias *.{{ vhost.domain.punnycode }} {{ vhost.domain.punnycode }}
 	{% endif %}
-	ServerAdmin admin@{{ vhost.domain }}
+	ServerAdmin admin@{{ vhost.domain.punnycode }}
 	# directory
 	DocumentRoot "{{ vhost.webroot }}/htdocs"
 	<Directory "{{ vhost.webroot }}/htdocs">


### PR DESCRIPTION
Implement IDN / Punnycode support for kumquat. The domain name is stored in punnycode format in the database and the default output is unicode. We have some methods that are able to convert the name to punnycode which is required for the backend services and configuration files.

Tested on:
- MacOS X
- SmartOS Zone