### PR TITLE
Fix issue #25, Remove ssl certificates which are not used by kumquat

### DIFF
--- a/kumquat/management/commands/update_vhosts.py
+++ b/kumquat/management/commands/update_vhosts.py
@@ -8,8 +8,13 @@ import uuid
 import os
 
 def write_certs():
+	file_list = []
 	for cert in SSLCert.objects.all():
 		cert.write_bundle()
+		file_list += [os.path.basename(cert.bundle_name())]
+	for f in os.listdir(settings.KUMQUAT_CERT_PATH):
+		if f not in file_list:
+			os.unlink(settings.KUMQUAT_CERT_PATH + '/' + f)
 
 def write_vhost_config():
 	config = ''

--- a/kumquat_web/settings.py
+++ b/kumquat_web/settings.py
@@ -146,7 +146,7 @@ LOGGING = {
 # kumquat
 
 KUMQUAT_BACKEND_SOCKET   = "ipc:///tmp/kumquat_backend"
-KUMQUAT_CERT_PATH        = '/opt/local/etc/openssl/httpd/'
+KUMQUAT_CERT_PATH        = '/opt/local/etc/openssl/kumquat/'
 KUMQUAT_VHOST_CONFIG     = '/opt/local/etc/httpd/vhosts.conf'
 KUMQUAT_VHOST_ROOT       = '/srv/www/'
 KUMQUAT_VHOST_UID        = 501


### PR DESCRIPTION
Kumquat requires to use extra ssl folder which only contains ssl certificates which are managed by the kumquat service. On vhost config it automatically checks and remove old / unused ssl certificates.

https://github.com/skylime/mi-core-kumquat/commit/c6ec79e52d1528bc5ab1d6f723d3c10bb0670d67