### PR TITLE
Fix permissions for the logs folder

### DIFF
--- a/kumquat/management/commands/update_vhosts.py
+++ b/kumquat/management/commands/update_vhosts.py
@@ -54,7 +54,7 @@ def update_vhosts():
 			os.makedirs(webroot(vhost))
 		os.makedirs(webroot(vhost) + '/htdocs')
 		os.makedirs(webroot(vhost) + '/logs')
-		for p in [webroot(vhost), webroot(vhost) + '/htdocs']:
+		for p in [webroot(vhost), webroot(vhost) + '/logs', webroot(vhost) + '/htdocs']:
 			os.chown(p, settings.KUMQUAT_VHOST_UID, settings.KUMQUAT_VHOST_GID)
 		if settings.KUMQUAT_VHOST_POST_CREATE_CMD:
 			call(settings.KUMQUAT_VHOST_POST_CREATE_CMD + [webroot(vhost)])


### PR DESCRIPTION
The logs folder should (and need to be) owned by the same user who are able to access the folder via FTP. If the permissions are not set the folder is owned by root:kumquat with 0770 permission mask.