### PR TITLE
Add simple support for KUMQUAT_SITE_NAME variable

### DIFF
--- a/kumquat_web/settings.py
+++ b/kumquat_web/settings.py
@@ -161,6 +161,7 @@ LOGGING = {
 }
 
 # kumquat
+KUMQUAT_SITE_NAME        = ''
 
 KUMQUAT_BACKEND_SOCKET   = "ipc:///tmp/kumquat_backend"
 KUMQUAT_CERT_PATH        = '/opt/local/etc/openssl/kumquat/'
@@ -200,4 +201,5 @@ SETTINGS_EXPORT = [
 	'KUMQUAT_PHPMYADMIN_URL',
 	'KUMQUAT_USE_ZFS',
 	'KUMQUAT_USE_0RPC',
+	'KUMQUAT_SITE_NAME',
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		<title>{% block title %}Kumquat{% endblock %}</title>
+		<title>{% block title %}Kumquat{% if settings.KUMQUAT_SITE_NAME %} - {{ settings.KUMQUAT_SITE_NAME }}{% endif %}{% endblock %}</title>
 		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
 		<style>
@@ -81,7 +81,7 @@
 		<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
 			<div class="container-fluid">
 				<div class="navbar-header">
-					<a class="navbar-brand" href="{% url 'status' %}">Kumquat</a>
+					<a class="navbar-brand" href="{% url 'status' %}">Kumquat{% if settings.KUMQUAT_SITE_NAME %} - {{ settings.KUMQUAT_SITE_NAME }}{% endif %}</a>
 				</div>
 				<div class="navbar-collapse collapse">
 					<ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
This variable could be used to customise the kumquat name, for example
to add or set the current hostname of the instance. This would help to solve
the issue #47