### PR TITLE
HotFix: Renew of SSL certificates does not work

### DIFF
--- a/kumquat/management/commands/letsencrypt.py
+++ b/kumquat/management/commands/letsencrypt.py
@@ -119,7 +119,7 @@ def issue_cert():
 
 		pkey_pem = None
 		if vhost.letsencrypt_state() is 'RENEW':
-			pkey_pem = vhost.key
+			pkey_pem = vhost.cert.key
 
 		# Generate a certificate request based on the vhost and aliases.
 		pkey_pem, csr_pem = gen_csr([str(vhost.punycode()),] + [vhostalias.punycode() for vhostalias in vhost.vhostalias_set.all()], pkey_pem)


### PR DESCRIPTION
We would like to re-use the key of an existing SSL certificate if it
exists. But we didn't access the correct details to receive the key.