### PR TITLE
Fix umask for directories create by Kumquat backend

### DIFF
--- a/kumquat/management/commands/backend.py
+++ b/kumquat/management/commands/backend.py
@@ -104,4 +104,5 @@ class Command(BaseCommand):
 		os.umask(0o007)
 		s = zerorpc.Server(Backend())
 		s.bind(settings.KUMQUAT_BACKEND_SOCKET)
+		os.umask(0o002)
 		s.run()


### PR DESCRIPTION
To provide a secure backend service we set the umask for the socket. But
this option result in an umask for all folders and files created by the
backend service.

For example:

  770 for htdocs folder
  770 for logs folder

Both owned by www user and group. So the Kumquat web service isn't able
to access the error.log and display it correclty in the UI.