### PR TITLE
Let's Encrypt Overview and Timeout handling

### DIFF
--- a/kumquat/management/commands/letsencrypt.py
+++ b/kumquat/management/commands/letsencrypt.py
@@ -12,6 +12,7 @@ import os
 import io
 import pstats
 import re
+import sys
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -114,9 +115,14 @@ def issue_cert():
 	if not vhosts:
 		return
 
-	net = client.ClientNetwork(key = key, account = regr)
-	directory = messages.Directory.from_json(net.get(settings.LETSENCRYPT_ACME_SERVER).json())
-	client_acme = client.ClientV2(directory, net=net)
+	try:
+		net = client.ClientNetwork(key = key, account = regr)
+		directory = messages.Directory.from_json(net.get(settings.LETSENCRYPT_ACME_SERVER).json())
+		client_acme = client.ClientV2(directory, net=net)
+	except Exception as e:
+		sys.stderr.write("Connection issues to " + str(settings.LETSENCRYPT_ACME_SERVER) + "\n")
+		sys.stderr.write("Verify current Let's Encrypt status via https://letsencrypt.status.io/\n")
+		sys.exit(1)
 
 	letsencrypt_issued = False
 	for vhost in vhosts:

--- a/status/templates/status/status.html
+++ b/status/templates/status/status.html
@@ -69,9 +69,35 @@
 		<td>{{info.mem.mem_nover}}</td>
 	</tr>
 	{% endif %}
-</tr>
 </tbody>
 </table>
+
+	{% if le_info %}
+	<h3>{% trans "Let's Encrypt Status" %}</h3>
+	<table class="table table-bordered table-hover">
+	<tbody>
+		{% for le in le_info %}
+		<tr>
+			<td><a href="{% url "web_vhost_update" le.vhost.pk %}">{{ le.vhost }}</a></td>
+			<td>
+			{% if le.vhost.letsencrypt_state == 'REQUEST' %}
+				<span class="label label-info">
+					{% trans "Requesting" %}
+			{% elif le.vhost.letsencrypt_state == 'VALID' %}
+				<span class="label label-success">
+					{% trans "Valid" %}
+			{% elif le.vhost.letsencrypt_state == 'RENEW' %}
+				<span class="label label-warning">
+					{% trans "Renewing" %}
+			{% endif %}
+				</span>
+			</td>
+			<td>{{ le.last_message|truncatechars:120 }}</td>
+		</tr>
+		{% endfor %}
+	</tbody>
+	</table>
+	{% endif %}
 
 
 

--- a/status/views.py
+++ b/status/views.py
@@ -1,7 +1,9 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from status.info import info
+from web.models import LetsEncrypt, SSLCert
 
 @login_required
 def status(request):
-	return render(request, 'status/status.html', {'info': info()})
+	le_info = LetsEncrypt.objects.exclude(last_message__isnull=True).exclude(last_message__exact='')
+	return render(request, 'status/status.html', {'info': info(), 'le_info': le_info})


### PR DESCRIPTION
Add a simple (minimal) overview about the issues in Let's Encrypt requests. This should show users issues about any Let's Encrypt order and link to the virtual host. Partly solve https://github.com/wiedi/kumquat/issues/64

Handle timeouts to the Let's Encrypt servers a bit better, especially timeouts to the directory services. We should consider of ignoring these errors or log them only because they happen from time to time.