### PR TITLE
Fix PHP-FPM handler matching non-existent files

### DIFF
--- a/web/templates/web/vhost.conf
+++ b/web/templates/web/vhost.conf
@@ -18,7 +18,9 @@
 	# php-fpm
 	{% if vhost.php_socket_path %}
 	<FilesMatch \.php$>
-		SetHandler "proxy:unix:{{ vhost.php_socket_path }}|fcgi://localhost"
+		<If "-f %{REQUEST_FILENAME}">
+			SetHandler "proxy:unix:{{ vhost.php_socket_path }}|fcgi://localhost"
+		</If>
 	</FilesMatch>
 	{% endif %}
 	# logging
@@ -56,7 +58,9 @@
 	# php-fpm
 	{% if vhost.php_socket_path %}
 	<FilesMatch \.php$>
-		SetHandler "proxy:unix:{{ vhost.php_socket_path }}|fcgi://localhost"
+		<If "-f %{REQUEST_FILENAME}">
+			SetHandler "proxy:unix:{{ vhost.php_socket_path }}|fcgi://localhost"
+		</If>
 	</FilesMatch>
 	{% endif %}
 	# logging


### PR DESCRIPTION
Without a file existence check, Apache's FilesMatch directive passes all requests matching *.php to PHP-FPM — including paths that do not exist on disk. This causes issues with frameworks using front-controller patterns (e.g. app.php/route) and can expose PHP-FPM to unnecessary requests for non-existent paths, potentially resulting in unexpected 502 errors or security-relevant information leakage via FPM error responses.

Wrapping SetHandler in an <If "-f %{REQUEST_FILENAME}"> condition ensures the proxy is only engaged when the requested .php file actually exists, allowing mod_rewrite and other handlers to take over for virtual paths.

References:
- https://httpd.apache.org/docs/current/expr.html
- https://wiki.apache.org/httpd/PHP-FPM